### PR TITLE
Fix follow() method to prevent a double content request

### DIFF
--- a/haleasy.py
+++ b/haleasy.py
@@ -143,7 +143,7 @@ class HALEasyLink(dougrain.link.Link):
         else:
             url = self.url(**link_params)
             response = self.HTTP_CLIENT_CLASS.request(url, method=method, data=data)
-            return self._hal_class(response.url, response.text, preview=self.preview)
+            return self._hal_class(response.url, json_str=response.text, preview=self.preview)
 
     def __getitem__(self, item):
         return self.as_object()[item]


### PR DESCRIPTION
The follow method gets the response text from line 145 and passes it to a new HAL object in line 146, however it passes the text as a non-named parameter.
As a result, the HAL object constructor ignores this response text, and calls a request to `response.url` _again_ when it constructs the object.
This fix passes the `response.text` to the named `json_str` parameter, as I believe was originally intended. This prevents the constructor calling request on the url again.
I've tested this fix in my project and it doesn't seem to break anything.